### PR TITLE
Increased time delays, and allow pull requests on multiple tabs

### DIFF
--- a/castervoice/doc/readthedocs/Application_Commands_Quick_Reference.md
+++ b/castervoice/doc/readthedocs/Application_Commands_Quick_Reference.md
@@ -153,8 +153,8 @@
 
 | Command                                  | Notes                                                                       |
 |:-----------------------------------------|:----------------------------------------------------------------------------|
-| `checkout [this] pull request [locally]` | Must be called from the "Conversation" tab of the Github pull request page. |
-| `update [this] pull request [locally]`   | Must be called from the "Conversation" tab of the Github pull request page. |
+| `checkout [this] pull request [locally]` | Called from any tab of the Github pull request page. ("Conversation", "Commits", "Checks", "Files changed")|
+| `update [this] pull request [locally]`   | Called from any tab of the Github pull request page. ("Conversation", "Commits", "Checks", "Files changed")|
 
 ## Click by voice plug-in
 Options:
@@ -253,8 +253,8 @@ Options:
 
 | Command                                  | Notes                                                                       |
 |:-----------------------------------------|:----------------------------------------------------------------------------|
-| `checkout [this] pull request [locally]` | Must be called from the "Conversation" tab of the Github pull request page. |
-| `update [this] pull request [locally]`   | Must be called from the "Conversation" tab of the Github pull request page. |
+| `checkout [this] pull request [locally]` | Called from any tab of the Github pull request page. ("Conversation", "Commits", "Checks", "Files changed") |
+| `update [this] pull request [locally]`   | Called from any tab of the Github pull request page. ("Conversation", "Commits", "Checks", "Files changed") |
 
 # Flash Develop
 

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -2,6 +2,7 @@
 
 import io
 import os
+from pywinauto import application
 import shutil
 import sys
 import traceback
@@ -48,20 +49,23 @@ def github_checkoutupdate_pull_request(new):
             if repo_url in items:
                 local_directory = items[repo_url][0]
                 local_directory = local_directory.replace("\\", "\\\\")
+                directory_command = "cd " + local_directory
                 TERMINAL_PATH = settings.SETTINGS["paths"]["TERMINAL_PATH"]
                 fetch_command = "git fetch " + repo_url + ".git pull/" + pr_name + "/head"
                 if TERMINAL_PATH != "":
-                    terminal = Popen(TERMINAL_PATH, cwd=local_directory)
+                    app = application.Application()
+                    app.start(TERMINAL_PATH)
+                    # terminal = Popen(TERMINAL_PATH, cwd=local_directory)
                     # This can be improved with a wait command
-                    time.sleep(5)
+                    # time.sleep(5)
                     if new:
                         branch_name_base = repo_url.replace("https://github.com/", "")
                         checkout_command = "git checkout -b " + branch_name_base + "/pull/" + pr_name + " FETCH_HEAD"
-                        Text(fetch_command + " && " + checkout_command).execute()
+                        Text(directory_command + " && " + fetch_command + " && " + checkout_command).execute()
                     else:
                         branch_name_base = repo_url.replace("https://github.com/", "")
                         checkout_command = "git checkout " + branch_name_base + "/pull/" + pr_name
-                        Text(fetch_command + " && " + checkout_command).execute()
+                        Text(directory_command + " && " + fetch_command + " && " + checkout_command).execute()
                         Key("enter").execute() # checkout is safe enough so will run this
                         merge_command = "git merge FETCH_HEAD"
                         time.sleep(3)

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -38,7 +38,7 @@ def github_checkoutupdate_pull_request(new):
         if url[0] == 0:
             split_string = url[1].split("/pull/")
             repo_url = split_string[0]
-            pr_name = split_string[1]
+            pr_name = split_string[1].split("/")[0]
             CONFIG = load_toml_file(settings.SETTINGS["paths"]["GIT_REPO_LOCAL_REMOTE_PATH"])
             if not CONFIG:
                 # logger.warn("Could not load bringme defaults")
@@ -53,22 +53,18 @@ def github_checkoutupdate_pull_request(new):
                 if TERMINAL_PATH != "":
                     terminal = Popen(TERMINAL_PATH, cwd=local_directory)
                     # This can be improved with a wait command
-                    time.sleep(2)
-                    Text(fetch_command).execute()
-                    time.sleep(0.2)
-                    Key("enter").execute() # fetch is safe enough so will run this
-                    time.sleep(0.2)
+                    time.sleep(5)
                     if new:
                         branch_name_base = repo_url.replace("https://github.com/", "")
                         checkout_command = "git checkout -b " + branch_name_base + "/pull/" + pr_name + " FETCH_HEAD"
-                        Text(checkout_command).execute()
+                        Text(fetch_command + " && " + checkout_command).execute()
                     else:
                         branch_name_base = repo_url.replace("https://github.com/", "")
                         checkout_command = "git checkout " + branch_name_base + "/pull/" + pr_name
-                        Text(checkout_command).execute()
+                        Text(fetch_command + " && " + checkout_command).execute()
                         Key("enter").execute() # checkout is safe enough so will run this
                         merge_command = "git merge FETCH_HEAD"
-                        time.sleep(0.2)
+                        time.sleep(3)
                         Text(merge_command).execute()
                 else:
                     raise Exception('TERMINAL_PATH in <user_dir>/.caster/data/settings.toml is not set')

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import collections
 import io
 import os
+import platform
 import sys
 import toml
 import _winreg
@@ -53,10 +54,19 @@ HMC_SEPARATOR = "[hmc]"
 
 WSR = False
 
-if os.path.isfile('C:/Program Files/Git/git-bash.exe'):
-    TERMINAL_PATH_DEFAULT = "C:/Program Files/Git/git-bash.exe"
+if platform.architecture()[0] == "32bit":
+    if os.path.isfile('C:/Program Files (x86)/Git/git-bash.exe'):
+        TERMINAL_PATH_DEFAULT = "C:/Program Files (x86)/Git/git-bash.exe"
+    else:
+        TERMINAL_PATH_DEFAULT = ""
+elif platform.architecture()[0] == "64bit":
+    if os.path.isfile('C:/Program Files/Git/git-bash.exe'):
+        TERMINAL_PATH_DEFAULT = "C:/Program Files/Git/git-bash.exe"
+    else:
+        TERMINAL_PATH_DEFAULT = ""
 else:
     TERMINAL_PATH_DEFAULT = ""
+
 
 def get_platform_information():
     """Return a dictionary containing platform-specific information."""


### PR DESCRIPTION
[automate checking out pull request #498](https://github.com/dictation-toolbox/Caster/pull/498)
I tested the code changes, and it's very useful. My only issue was that git bash required slightly longer times to complete a command, hence I've done the following:

-Increased the 1st time delay to 5 seconds to allow time for the application to open up and initialise before a command is put in

- Increased the last time delay to 3 seconds to account for the small delay when switching branches before typing in the merge command

- Combined the fetching and check out commands into a pair of commands, separated, by a logical separator, to ensure the 2nd command of checking out is only performed once the fetching has completed.

I also changed the pull request name variable, so that the pull request voice command can be uttered on any of the other tabs of the pull request ("Conversation", "Commits", "Checks", "Files changed")