### PR TITLE
Switch from pywinauto to autohotkey to fix errors and speed up execution

### DIFF
--- a/castervoice/lib/github_automation.ahk
+++ b/castervoice/lib/github_automation.ahk
@@ -7,6 +7,6 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 SetTitleMatchMode, 2
 WinWait, MINGW64
 {
-	WinClose, MINGW64
+	
 }
 Return

--- a/castervoice/lib/github_automation.ahk
+++ b/castervoice/lib/github_automation.ahk
@@ -7,23 +7,23 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 SetTitleMatchMode, 2
 if (%1% = "exists")
 {
-	MsgBox %1%" Exists"
+	MsgBox ,, %1%" Exists"
 	if WinExist(%2%)
 	{
-		MsgBox %1%" Exists_2"
+		MsgBox , , %1%" Exists_2"
 		WinActivate, %2%
-		FileAppend %2%" activated", *
+		FileAppend,  %2%" activated", *
 	}
 	else
 	{
-		MsgBox %1%" Exists_3"
-		FileAppend %2%" does not exist", *
+		MsgBox , , %1%" Exists_3"
+		FileAppend , %2%" does not exist", *
 	}
 }
 else if (%1% = "create")
 {
 	WinWait, %2%
 	{
-		FileAppend %2%" ready", *
+		FileAppend , %2%" ready", *
 	}
 }

--- a/castervoice/lib/github_automation.ahk
+++ b/castervoice/lib/github_automation.ahk
@@ -5,11 +5,11 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 
 
 SetTitleMatchMode, 2
-if (%1 = "exists")
+if (%1% = "exists")
 {
-	if WinExist(%2)
+	if WinExist(%2%)
 	{
-		WinActivate, %2
+		WinActivate, %2%
 		FileAppend %2%" activated", *
 	}
 	else
@@ -17,9 +17,9 @@ if (%1 = "exists")
 		FileAppend %2%" does not exist", *
 	}
 }
-else if (%1 = "create")
+else if (%1% = "create")
 {
-	WinWait, %2
+	WinWait, %2%
 	{
 		FileAppend %2%" ready", *
 	}

--- a/castervoice/lib/github_automation.ahk
+++ b/castervoice/lib/github_automation.ahk
@@ -5,8 +5,22 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 
 
 SetTitleMatchMode, 2
-WinWait, MINGW64
+if (%1 = "exists")
 {
-	
+	if WinExist(%2)
+	{
+		WinActivate, %2
+		FileAppend %2%" activated", *
+	}
+	else
+	{
+		FileAppend %2%" does not exist", *
+	}
 }
-Return
+else if (%1 = "create")
+{
+	WinWait, %2
+	{
+		FileAppend %2%" ready", *
+	}
+}

--- a/castervoice/lib/github_automation.ahk
+++ b/castervoice/lib/github_automation.ahk
@@ -3,27 +3,33 @@
 SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
 SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 
+check := %1%
+title := %2%
+
+MsgBox , , "check=" . ", title=" . title
 
 SetTitleMatchMode, 2
-if (%1% = "exists")
+if (check == "exists")
 {
-	MsgBox ,, %1%" Exists"
-	if WinExist(%2%)
+	MsgBox ,, check . " Exists"
+	if WinExist(title)
 	{
-		MsgBox , , %1%" Exists_2"
-		WinActivate, %2%
-		FileAppend,  %2%" activated", *
+		MsgBox , , check . " Exists_2"
+		WinActivate, title
+		FileAppend,  title . " activated", *
 	}
 	else
 	{
-		MsgBox , , %1%" Exists_3"
-		FileAppend , %2%" does not exist", *
+		MsgBox , , check . " Exists_3"
+		FileAppend , title . " does not exist", *
 	}
 }
-else if (%1% = "create")
+else if (check = "create")
 {
-	WinWait, %2%
+	MsgBox , , check . " creates_4"
+	
+	WinWait, title
 	{
-		FileAppend , %2%" ready", *
+		FileAppend , title . " ready", *
 	}
 }

--- a/castervoice/lib/github_automation.ahk
+++ b/castervoice/lib/github_automation.ahk
@@ -6,28 +6,21 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 check = %1%
 title = %2%
 
-MsgBox , , , "check=" %check% " title=" %title%
-
 SetTitleMatchMode, 2
 if (check == "exists")
 {
-	MsgBox ,, , %check% " Exists"
 	if WinExist(title)
 	{
-		MsgBox , , , %check% Exists_2
 		WinActivate, %title%
 		FileAppend,  %title% activated, *
 	}
 	else
 	{
-		MsgBox , , , %check% Exists_3
 		FileAppend , %title% does not exist, *
 	}
 }
 else if (check = "create")
 {
-	MsgBox , , , %check% creates_4
-	
 	WinWait, %title%
 	{
 		FileAppend , %title% ready, *

--- a/castervoice/lib/github_automation.ahk
+++ b/castervoice/lib/github_automation.ahk
@@ -7,13 +7,16 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 SetTitleMatchMode, 2
 if (%1% = "exists")
 {
+	MsgBox %1%" Exists"
 	if WinExist(%2%)
 	{
+		MsgBox %1%" Exists_2"
 		WinActivate, %2%
 		FileAppend %2%" activated", *
 	}
 	else
 	{
+		MsgBox %1%" Exists_3"
 		FileAppend %2%" does not exist", *
 	}
 }

--- a/castervoice/lib/github_automation.ahk
+++ b/castervoice/lib/github_automation.ahk
@@ -3,33 +3,33 @@
 SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
 SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 
-check := %1%
-title := %2%
+check = %1%
+title = %2%
 
-MsgBox , , "check=" . ", title=" . title
+MsgBox , , , "check=" %check% " title=" %title%
 
 SetTitleMatchMode, 2
 if (check == "exists")
 {
-	MsgBox ,, check . " Exists"
+	MsgBox ,, , %check% " Exists"
 	if WinExist(title)
 	{
-		MsgBox , , check . " Exists_2"
-		WinActivate, title
-		FileAppend,  title . " activated", *
+		MsgBox , , , %check% Exists_2
+		WinActivate, %title%
+		FileAppend,  %title% activated, *
 	}
 	else
 	{
-		MsgBox , , check . " Exists_3"
-		FileAppend , title . " does not exist", *
+		MsgBox , , , %check% Exists_3
+		FileAppend , %title% does not exist, *
 	}
 }
 else if (check = "create")
 {
-	MsgBox , , check . " creates_4"
+	MsgBox , , , %check% creates_4
 	
-	WinWait, title
+	WinWait, %title%
 	{
-		FileAppend , title . " ready", *
+		FileAppend , %title% ready, *
 	}
 }

--- a/castervoice/lib/github_automation.ahk
+++ b/castervoice/lib/github_automation.ahk
@@ -1,0 +1,12 @@
+#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
+; #Warn  ; Enable warnings to assist with detecting common errors.
+SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
+SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
+
+
+SetTitleMatchMode, 2
+WinWait, MINGW64
+{
+	WinClose, MINGW64
+}
+Return

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -67,8 +67,8 @@ def github_checkoutupdate_pull_request(new):
                     ahk_script = __file__.replace(".py", ".ahk")
                     #raise Exception("ahk_script=", ahk_script)
                     pattern_match = "MINGW64"
-                    # p = call([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
-                    p = Popen([AHK_PATH, ahk_script," exists "], stdout=PIPE)
+                    # p = call([AHK_PATH, ahk_script, "exists"], stdout=PIPE
+                    p = Popen([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
                     stdout, stderr = p.communicate()
                     p.terminate()
                     #raise stdout

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -73,7 +73,7 @@ def github_checkoutupdate_pull_request(new):
                     p.terminate()
                     #raise stdout
                     #raise stderr
-                    raise Exception("exists msg: stdout = " + str(stdout) + ", stderr = " + str(stderr))
+                    #raise Exception("exists msg: stdout = " + str(stdout) + ", stderr = " + str(stderr))
 
                     fetch_command = ""
                     if stdout == pattern_match + " activated":
@@ -87,9 +87,10 @@ def github_checkoutupdate_pull_request(new):
                         #raise stderr
                         raise Exception("create msg: stdout = " + str(stdout) + ", stderr = " + str(stderr))
                         p.terminate()
+                        if stdout != pattern_match + " ready":
+                            raise Exception("Error: git bash terminal was not ready.")
                     fetch_command += "git fetch " + repo_url + ".git pull/" + pr_name + "/head"
-                    if stdout != pattern_match + " ready":
-                        raise Exception("Error: git bash terminal was not ready.")
+
                     if new:
                         branch_name_base = repo_url.replace("https://github.com/", "")
                         checkout_command = "git checkout -b " + branch_name_base + "/pull/" + pr_name + " FETCH_HEAD"

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -62,18 +62,20 @@ def github_checkoutupdate_pull_request(new):
                     #ahk_script = os.path.splitext(os.path.basename(__file__))[0] + ".ahk"
                     ahk_script = __file__.replace(".py",".ahk")
                     pattern_match = "MINGW64"
-                    p = call([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
-                    # p = Popen([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
+                    # p = call([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
+                    p = Popen([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
                     stdout, stderr = p.communicate()
+                    raise("exists msg: stdout = " + stdout + ", stderr = " + stderr)
                     p.terminate()
                     fetch_command = ""
                     if stdout == pattern_match + " activated":
                         fetch_command += directory_command + " && "
                     elif stdout == pattern_match + " does not exist":
                         terminal = Popen(TERMINAL_PATH, cwd=local_directory)
-                        #p = Popen([AHK_PATH, ahk_script, "create"], stdout=PIPE)
-                        p = call([AHK_PATH, ahk_script, "create"], stdout=PIPE)
+                        p = Popen([AHK_PATH, ahk_script, "create"], stdout=PIPE)
+                        #p = call([AHK_PATH, ahk_script, "create"], stdout=PIPE)
                         stdout, stderr = p.communicate()
+                        raise ("create msg: stdout = " + stdout + ", stderr = " + stderr)
                         p.terminate()
                     fetch_command += "git fetch " + repo_url + ".git pull/" + pr_name + "/head"
                     if stdout != pattern_match + " ready":

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -72,7 +72,7 @@ def github_checkoutupdate_pull_request(new):
                     p.terminate()
                     #raise stdout
                     #raise stderr
-                    raise Exception("exists msg: stdout = " + stdout + ", stderr = " + stderr)
+                    raise Exception("exists msg: stdout = " + str(stdout) + ", stderr = " + str(stderr))
 
                     fetch_command = ""
                     if stdout == pattern_match + " activated":
@@ -84,7 +84,7 @@ def github_checkoutupdate_pull_request(new):
                         stdout, stderr = p.communicate()
                         #raise stdout
                         #raise stderr
-                        raise Exception("create msg: stdout = " + stdout + ", stderr = " + stderr)
+                        raise Exception("create msg: stdout = " + str(stdout) + ", stderr = " + str(stderr))
                         p.terminate()
                     fetch_command += "git fetch " + repo_url + ".git pull/" + pr_name + "/head"
                     if stdout != pattern_match + " ready":

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -31,6 +31,10 @@ def rebuild_local_remote_items(config):
         for header, section in config.iteritems() for key, value in section.iteritems()
     }
 
+
+stdout = ""
+
+
 def github_checkoutupdate_pull_request(new):
     # Function to fetch a PR
     try:
@@ -104,4 +108,4 @@ def github_checkoutupdate_pull_request(new):
             else:
                 raise Exception("Repository URL: " + repo_url + " not found in " + settings.SETTINGS["paths"]["GIT_REPO_LOCAL_REMOTE_PATH"])
     except Exception as e:
-        print (e)
+        print (e, stdout, ", ", stderr)

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -85,10 +85,10 @@ def github_checkoutupdate_pull_request(new):
                         stdout, stderr = p.communicate()
                         #raise stdout
                         #raise stderr
-                        raise Exception("create msg: stdout = " + str(stdout) + ", stderr = " + str(stderr))
+                        #raise Exception("create msg: stdout = " + str(stdout) + ", stderr = " + str(stderr))
                         p.terminate()
                         if stdout != pattern_match + " ready":
-                            raise Exception("Error: git bash terminal was not ready.")
+                            raise Exception("Error: git bash terminal took too long to load.")
                     fetch_command += "git fetch " + repo_url + ".git pull/" + pr_name + "/head"
 
                     if new:

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -2,12 +2,12 @@
 
 import io
 import os
-from pywinauto import application
+#from pywinauto import application
 import shutil
 import sys
 import traceback
 from __builtin__ import True
-from subprocess import Popen
+from subprocess import Popen, call
 import toml
 import time
 
@@ -51,21 +51,27 @@ def github_checkoutupdate_pull_request(new):
                 local_directory = local_directory.replace("\\", "\\\\")
                 directory_command = "cd " + local_directory
                 TERMINAL_PATH = settings.SETTINGS["paths"]["TERMINAL_PATH"]
+                AHK_PATH = settings.SETTINGS["paths"]["AHK_PATH"]
                 fetch_command = "git fetch " + repo_url + ".git pull/" + pr_name + "/head"
                 if TERMINAL_PATH != "":
-                    app = application.Application()
-                    app.start(TERMINAL_PATH)
-                    # terminal = Popen(TERMINAL_PATH, cwd=local_directory)
+                    #app = application.Application()
+                    #app.start(TERMINAL_PATH)
+                    terminal = Popen(TERMINAL_PATH, cwd=local_directory)
                     # This can be improved with a wait command
                     # time.sleep(5)
+                    ahk_script = os.path.splitext(os.path.basename(__file__))[0] + ".ahk"
+                    call([AHK_PATH, ahk_script])
+
                     if new:
                         branch_name_base = repo_url.replace("https://github.com/", "")
                         checkout_command = "git checkout -b " + branch_name_base + "/pull/" + pr_name + " FETCH_HEAD"
-                        Text(directory_command + " && " + fetch_command + " && " + checkout_command).execute()
+                        #Text(directory_command + " && " + fetch_command + " && " + checkout_command).execute()
+                        Text(fetch_command + " && " + checkout_command).execute()
                     else:
                         branch_name_base = repo_url.replace("https://github.com/", "")
                         checkout_command = "git checkout " + branch_name_base + "/pull/" + pr_name
-                        Text(directory_command + " && " + fetch_command + " && " + checkout_command).execute()
+                        #Text(directory_command + " && " + fetch_command + " && " + checkout_command).execute()
+                        Text(fetch_command + " && " + checkout_command).execute()
                         Key("enter").execute() # checkout is safe enough so will run this
                         merge_command = "git merge FETCH_HEAD"
                         time.sleep(3)

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -65,8 +65,11 @@ def github_checkoutupdate_pull_request(new):
                     # p = call([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
                     p = Popen([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
                     stdout, stderr = p.communicate()
-                    raise("exists msg: stdout = " + stdout + ", stderr = " + stderr)
                     p.terminate()
+                    raise stdout
+                    raise stderr
+                    raise("exists msg: stdout = " + stdout + ", stderr = " + stderr)
+
                     fetch_command = ""
                     if stdout == pattern_match + " activated":
                         fetch_command += directory_command + " && "
@@ -75,7 +78,9 @@ def github_checkoutupdate_pull_request(new):
                         p = Popen([AHK_PATH, ahk_script, "create"], stdout=PIPE)
                         #p = call([AHK_PATH, ahk_script, "create"], stdout=PIPE)
                         stdout, stderr = p.communicate()
-                        raise ("create msg: stdout = " + stdout + ", stderr = " + stderr)
+                        raise stdout
+                        raise stderr
+                        raise("create msg: stdout = " + stdout + ", stderr = " + stderr)
                         p.terminate()
                     fetch_command += "git fetch " + repo_url + ".git pull/" + pr_name + "/head"
                     if stdout != pattern_match + " ready":

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -70,9 +70,9 @@ def github_checkoutupdate_pull_request(new):
                     p = Popen([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
                     stdout, stderr = p.communicate()
                     p.terminate()
-                    raise stdout
-                    raise stderr
-                    raise("exists msg: stdout = " + stdout + ", stderr = " + stderr)
+                    #raise stdout
+                    #raise stderr
+                    raise Exception("exists msg: stdout = " + stdout + ", stderr = " + stderr)
 
                     fetch_command = ""
                     if stdout == pattern_match + " activated":
@@ -82,9 +82,9 @@ def github_checkoutupdate_pull_request(new):
                         p = Popen([AHK_PATH, ahk_script, "create"], stdout=PIPE)
                         #p = call([AHK_PATH, ahk_script, "create"], stdout=PIPE)
                         stdout, stderr = p.communicate()
-                        raise stdout
-                        raise stderr
-                        raise("create msg: stdout = " + stdout + ", stderr = " + stderr)
+                        #raise stdout
+                        #raise stderr
+                        raise Exception("create msg: stdout = " + stdout + ", stderr = " + stderr)
                         p.terminate()
                     fetch_command += "git fetch " + repo_url + ".git pull/" + pr_name + "/head"
                     if stdout != pattern_match + " ready":

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -68,7 +68,7 @@ def github_checkoutupdate_pull_request(new):
                     #raise Exception("ahk_script=", ahk_script)
                     pattern_match = "MINGW64"
                     # p = call([AHK_PATH, ahk_script, "exists"], stdout=PIPE
-                    p = Popen([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
+                    p = Popen([AHK_PATH, ahk_script, "exists", pattern_match], stdout=PIPE)
                     stdout, stderr = p.communicate()
                     p.terminate()
                     #raise stdout
@@ -80,7 +80,7 @@ def github_checkoutupdate_pull_request(new):
                         fetch_command += directory_command + " && "
                     elif stdout == pattern_match + " does not exist":
                         terminal = Popen(TERMINAL_PATH, cwd=local_directory)
-                        p = Popen([AHK_PATH, ahk_script, "create"], stdout=PIPE)
+                        p = Popen([AHK_PATH, ahk_script, "create", pattern_match], stdout=PIPE)
                         #p = call([AHK_PATH, ahk_script, "create"], stdout=PIPE)
                         stdout, stderr = p.communicate()
                         #raise stdout

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -2,12 +2,11 @@
 
 import io
 import os
-#from pywinauto import application
 import shutil
 import sys
 import traceback
 from __builtin__ import True
-from subprocess import Popen, call, PIPE
+from subprocess import Popen, PIPE
 import toml
 import time
 
@@ -24,15 +23,13 @@ if os.path.isfile(settings.SETTINGS["paths"]["GIT_REPO_LOCAL_REMOTE_PATH"]) is F
     git_match_user = settings.SETTINGS["paths"]["GIT_REPO_LOCAL_REMOTE_PATH"]
     shutil.copy(git_match_default, git_match_user)
 
+
 def rebuild_local_remote_items(config):
     # logger.debug('Github rebuilding extras')
     return {
         key: (os.path.expandvars(value), header)
         for header, section in config.iteritems() for key, value in section.iteritems()
     }
-
-
-stdout = ""
 
 
 def github_checkoutupdate_pull_request(new):
@@ -56,57 +53,54 @@ def github_checkoutupdate_pull_request(new):
                 directory_command = "cd " + local_directory
                 TERMINAL_PATH = settings.SETTINGS["paths"]["TERMINAL_PATH"]
                 AHK_PATH = settings.SETTINGS["paths"]["AHK_PATH"]
-                # fetch_command = "git fetch " + repo_url + ".git pull/" + pr_name + "/head"
                 if TERMINAL_PATH != "" and AHK_PATH != "":
-                    #app = application.Application()
-                    #app.start(TERMINAL_PATH)
-
-                    # This can be improved with a wait command
-                    # time.sleep(5)
-                    #ahk_script = os.path.splitext(os.path.basename(__file__))[0] + ".ahk"
+                    # find the equivalent ahk script with the same name as this one
                     ahk_script = __file__.replace(".py", ".ahk")
-                    #raise Exception("ahk_script=", ahk_script)
-                    pattern_match = "MINGW64"
-                    # p = call([AHK_PATH, ahk_script, "exists"], stdout=PIPE
+                    pattern_match = "MINGW64"  # the string we expect to find in the title of git bash when loaded
+                    # open the script which checks that git bash window is open or not
                     p = Popen([AHK_PATH, ahk_script, "exists", pattern_match], stdout=PIPE)
+                    # retrieve the output from the ahk script
                     stdout, stderr = p.communicate()
+                    # terminates the ahk script if not already done so
                     p.terminate()
-                    #raise stdout
-                    #raise stderr
-                    #raise Exception("exists msg: stdout = " + str(stdout) + ", stderr = " + str(stderr))
-
+                    # ready fetch command string to be appended to
                     fetch_command = ""
+                    # if an existing git bash window has been activated
                     if stdout == pattern_match + " activated":
+                        # set the first portion of the fetch command
                         fetch_command += directory_command + " && "
+                    # if an existing git bash window is not already open
                     elif stdout == pattern_match + " does not exist":
+                        # open up a new git bash terminal
                         terminal = Popen(TERMINAL_PATH, cwd=local_directory)
+                        # open the script which checks that git bash windoow is ready or not for input
                         p = Popen([AHK_PATH, ahk_script, "create", pattern_match], stdout=PIPE)
-                        #p = call([AHK_PATH, ahk_script, "create"], stdout=PIPE)
+                        # retrieve the output from the AHK script
                         stdout, stderr = p.communicate()
-                        #raise stdout
-                        #raise stderr
-                        #raise Exception("create msg: stdout = " + str(stdout) + ", stderr = " + str(stderr))
+                        # terminates the ahk script if not already done so
                         p.terminate()
+                        # if the git bash terminal is not ready
                         if stdout != pattern_match + " ready":
                             raise Exception("Error: git bash terminal took too long to load.")
+                    # adds to the fetch command string that which will fetch from the particular repository in question
                     fetch_command += "git fetch " + repo_url + ".git pull/" + pr_name + "/head"
-
+                    # if fetching from a new pull request
                     if new:
                         branch_name_base = repo_url.replace("https://github.com/", "")
                         checkout_command = "git checkout -b " + branch_name_base + "/pull/" + pr_name + " FETCH_HEAD"
-                        #Text(directory_command + " && " + fetch_command + " && " + checkout_command).execute()
+                        # type in the full command into the git bash window
                         Text(fetch_command + " && " + checkout_command).execute()
-                    else:
+                    else:  # otherwise if it is an update to an existing pull request
                         branch_name_base = repo_url.replace("https://github.com/", "")
                         checkout_command = "git checkout " + branch_name_base + "/pull/" + pr_name
-                        #Text(directory_command + " && " + fetch_command + " && " + checkout_command).execute()
+                        # type in the full command into the git bash window
                         Text(fetch_command + " && " + checkout_command).execute()
-                        Key("enter").execute() # checkout is safe enough so will run this
+                        Key("enter").execute()  # checkout is safe enough so will run this
                         merge_command = "git merge FETCH_HEAD"
-                        time.sleep(3)
+                        time.sleep(3)  # allow time for the fetch commands complete before typing in the next one
                         Text(merge_command).execute()
                 else:
-                    raise Exception('TERMINAL_PATH in <user_dir>/.caster/data/settings.toml is not set')
+                    raise Exception('TERMINAL_PATH in <user_dir>/.caster/data/settings.toml is not set, or AHK_PATH in castrvoice/lib/settings.py')
             else:
                 raise Exception("Repository URL: " + repo_url + " not found in " + settings.SETTINGS["paths"]["GIT_REPO_LOCAL_REMOTE_PATH"])
     except Exception as e:

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -62,8 +62,8 @@ def github_checkoutupdate_pull_request(new):
                     #ahk_script = os.path.splitext(os.path.basename(__file__))[0] + ".ahk"
                     ahk_script = __file__.replace(".py",".ahk")
                     pattern_match = "MINGW64"
-                    # p = call([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
-                    p = Popen([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
+                    p = call([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
+                    # p = Popen([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
                     stdout, stderr = p.communicate()
                     p.terminate()
                     fetch_command = ""
@@ -71,7 +71,8 @@ def github_checkoutupdate_pull_request(new):
                         fetch_command += directory_command + " && "
                     elif stdout == pattern_match + " does not exist":
                         terminal = Popen(TERMINAL_PATH, cwd=local_directory)
-                        p = Popen([AHK_PATH, ahk_script, "create"], stdout=PIPE)
+                        #p = Popen([AHK_PATH, ahk_script, "create"], stdout=PIPE)
+                        p = call([AHK_PATH, ahk_script, "create"], stdout=PIPE)
                         stdout, stderr = p.communicate()
                         p.terminate()
                     fetch_command += "git fetch " + repo_url + ".git pull/" + pr_name + "/head"

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -65,10 +65,10 @@ def github_checkoutupdate_pull_request(new):
                     # time.sleep(5)
                     #ahk_script = os.path.splitext(os.path.basename(__file__))[0] + ".ahk"
                     ahk_script = __file__.replace(".py", ".ahk")
-                    raise Exception("ahk_script=", ahk_script)
+                    #raise Exception("ahk_script=", ahk_script)
                     pattern_match = "MINGW64"
                     # p = call([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
-                    p = Popen([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
+                    p = Popen([AHK_PATH + " " + ahk_script + " exists "], stdout=PIPE)
                     stdout, stderr = p.communicate()
                     p.terminate()
                     #raise stdout

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -109,4 +109,4 @@ def github_checkoutupdate_pull_request(new):
             else:
                 raise Exception("Repository URL: " + repo_url + " not found in " + settings.SETTINGS["paths"]["GIT_REPO_LOCAL_REMOTE_PATH"])
     except Exception as e:
-        print (e, stdout, ", ", stderr)
+        print (e)

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -64,7 +64,8 @@ def github_checkoutupdate_pull_request(new):
                     # This can be improved with a wait command
                     # time.sleep(5)
                     #ahk_script = os.path.splitext(os.path.basename(__file__))[0] + ".ahk"
-                    ahk_script = __file__.replace(".py",".ahk")
+                    ahk_script = __file__.replace(".py", ".ahk")
+                    raise Exception("ahk_script=", ahk_script)
                     pattern_match = "MINGW64"
                     # p = call([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
                     p = Popen([AHK_PATH, ahk_script, "exists"], stdout=PIPE)

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -59,7 +59,8 @@ def github_checkoutupdate_pull_request(new):
                     terminal = Popen(TERMINAL_PATH, cwd=local_directory)
                     # This can be improved with a wait command
                     # time.sleep(5)
-                    ahk_script = os.path.splitext(os.path.basename(__file__))[0] + ".ahk"
+                    #ahk_script = os.path.splitext(os.path.basename(__file__))[0] + ".ahk"
+                    ahk_script = __file__.replace(".py",".ahk")
                     call([AHK_PATH, ahk_script])
 
                     if new:

--- a/castervoice/lib/github_automation.py
+++ b/castervoice/lib/github_automation.py
@@ -68,7 +68,7 @@ def github_checkoutupdate_pull_request(new):
                     #raise Exception("ahk_script=", ahk_script)
                     pattern_match = "MINGW64"
                     # p = call([AHK_PATH, ahk_script, "exists"], stdout=PIPE)
-                    p = Popen([AHK_PATH + " " + ahk_script + " exists "], stdout=PIPE)
+                    p = Popen([AHK_PATH, ahk_script," exists "], stdout=PIPE)
                     stdout, stderr = p.communicate()
                     p.terminate()
                     #raise stdout

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -54,18 +54,29 @@ HMC_SEPARATOR = "[hmc]"
 
 WSR = False
 
-if platform.architecture()[0] == "32bit":
-    if os.path.isfile('C:/Program Files (x86)/Git/git-bash.exe'):
-        TERMINAL_PATH_DEFAULT = "C:/Program Files (x86)/Git/git-bash.exe"
-    else:
-        TERMINAL_PATH_DEFAULT = ""
-elif platform.architecture()[0] == "64bit":
-    if os.path.isfile('C:/Program Files/Git/git-bash.exe'):
-        TERMINAL_PATH_DEFAULT = "C:/Program Files/Git/git-bash.exe"
-    else:
-        TERMINAL_PATH_DEFAULT = ""
+# if platform.architecture()[0] == "32bit":
+#     if os.path.isfile('C:/Program Files (x86)/Git/git-bash.exe'):
+#         TERMINAL_PATH_DEFAULT = "C:/Program Files (x86)/Git/git-bash.exe"
+#     else:
+#         TERMINAL_PATH_DEFAULT = ""
+# elif platform.architecture()[0] == "64bit":
+#     if os.path.isfile('C:/Program Files/Git/git-bash.exe'):
+#         TERMINAL_PATH_DEFAULT = "C:/Program Files/Git/git-bash.exe"
+#     else:
+#         TERMINAL_PATH_DEFAULT = ""
+# else:
+#     TERMINAL_PATH_DEFAULT = ""
+
+if os.path.isfile('C:/Program Files/Git/git-bash.exe'):
+    TERMINAL_PATH_DEFAULT = "C:/Program Files/Git/git-bash.exe"
 else:
     TERMINAL_PATH_DEFAULT = ""
+
+if os.path.isfile('C:/Program Files/AutoHotkey/AutoHotkey.exe'):
+    AHK_PATH_DEFAULT = "C:/Program Files/AutoHotkey/AutoHotkey.exe"
+else:
+    AHK_PATH_DEFAULT = ""
+
 
 
 def get_platform_information():
@@ -209,6 +220,7 @@ _DEFAULT_SETTINGS = {
         "SIKULI_RUNNER": "",
 
         # EXECUTABLES
+        "AHK_PATH": AHK_PATH_DEFAULT,
         "DOUGLAS_PATH": BASE_PATH + "/asynch/mouse/grids.py",
         "ENGINE_PATH": _validate_engine_path(),
         "HOMUNCULUS_PATH": BASE_PATH + "/asynch/hmc/h_launch.py",

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 import collections
 import io
 import os
-import platform
 import sys
 import toml
 import _winreg
@@ -54,19 +53,7 @@ HMC_SEPARATOR = "[hmc]"
 
 WSR = False
 
-# if platform.architecture()[0] == "32bit":
-#     if os.path.isfile('C:/Program Files (x86)/Git/git-bash.exe'):
-#         TERMINAL_PATH_DEFAULT = "C:/Program Files (x86)/Git/git-bash.exe"
-#     else:
-#         TERMINAL_PATH_DEFAULT = ""
-# elif platform.architecture()[0] == "64bit":
-#     if os.path.isfile('C:/Program Files/Git/git-bash.exe'):
-#         TERMINAL_PATH_DEFAULT = "C:/Program Files/Git/git-bash.exe"
-#     else:
-#         TERMINAL_PATH_DEFAULT = ""
-# else:
-#     TERMINAL_PATH_DEFAULT = ""
-
+# set the paths for autohotkey and git bash
 if os.path.isfile('C:/Program Files/Git/git-bash.exe'):
     TERMINAL_PATH_DEFAULT = "C:/Program Files/Git/git-bash.exe"
 else:
@@ -76,7 +63,6 @@ if os.path.isfile('C:/Program Files/AutoHotkey/AutoHotkey.exe'):
     AHK_PATH_DEFAULT = "C:/Program Files/AutoHotkey/AutoHotkey.exe"
 else:
     AHK_PATH_DEFAULT = ""
-
 
 
 def get_platform_information():


### PR DESCRIPTION
[automate checking out pull request #498](https://github.com/dictation-toolbox/Caster/pull/498)
- I've removed the use of pywinauto to remove the error messages, and instead incorporated a short autohotkey script which **speeds things up** considerably (from several seconds to a single second). So the user only needs to install the latest version of [autohotkey](https://autohotkey.com/download/1.1/)

- I've also allowed for the fact that the might already be a git bash window open, so it will switch to an already open git bash window if it exists, otherwise, it will open up a new instance.