### PR TITLE
Add Cursor support

### DIFF
--- a/castervoice/rules/apps/editor/vscode_rules/vscode.py
+++ b/castervoice/rules/apps/editor/vscode_rules/vscode.py
@@ -149,7 +149,7 @@ class VSCodeCcrRule(MergeRule):
 
 
 def get_rule():
-    details = RuleDetails(executable="code",
+    details = RuleDetails(executable=["code", "cursor"],
                           title="Visual Studio Code",
                           ccrtype=CCRType.APP)
     return VSCodeCcrRule, details

--- a/castervoice/rules/apps/editor/vscode_rules/vscode2.py
+++ b/castervoice/rules/apps/editor/vscode_rules/vscode2.py
@@ -308,6 +308,6 @@ class VSCodeNonCcrRule(MappingRule):
 
 def get_rule():
     details = RuleDetails(name="Visual Studio Code",
-                          executable="code",
+                          executable=["code", "cursor"],
                           title="Visual Studio Code")
     return VSCodeNonCcrRule, details

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@
 
 - Supported [Applications](https://caster.readthedocs.io/en/latest/readthedocs/Caster_Commands/Application_Commands_Quick_Reference/)
 
-  - IDEs/Editors: Microsoft Visual C++, Visual Studio, Eclipse, Jetbrains IDEs, Emacs, Sublime, Atom, Visual Studio Code, Notepad++, FlashDevelop, Sql Developer, SQL Server Management Studio
+  - IDEs/Editors: Microsoft Visual C++, Visual Studio, Eclipse, Jetbrains IDEs, Emacs, Sublime, Atom, Visual Studio Code (including Cursor), Notepad++, FlashDevelop, Sql Developer, SQL Server Management Studio
   - Development Tools: Command Prompt, GitBash, KDiff3
   - Statistics: RStudio
   - Word Processor: lyx, Microsoft Word, Typora

--- a/docs/readthedocs/Caster_Commands/Application_Commands_Quick_Reference.md
+++ b/docs/readthedocs/Caster_Commands/Application_Commands_Quick_Reference.md
@@ -40,7 +40,7 @@ Classic Install Location: `castervoice\rules\apps'` in Caster source code.
 - [Typora](#typora) - tie poor a
 - [Unity](#unity) - unity
 - [Visual Studio](#visual-studio) - visual studio
-- [Visual Studio Code](#visual-studio-code) Visual Studio Code CCR/Visual Studio Code
+- [Visual Studio Code](#visual-studio-code) Visual Studio Code CCR/Visual Studio Code (Cursor compatible)
 - [Webex Teams](#webex-teams) - webex teams
 
 <!-- /TOC -->
@@ -655,7 +655,7 @@ These commands are for Windows/Linux and creating a separate command ruleset for
 | `collapse to definitions`          | `quick launch`               | `undo (checkout / pending changes)` |
 | `comment block`                    |                              |                                     |
 
-## Visual Studio Code
+## Visual Studio Code / Cursor
 
 ## CCR (Continuous Command Recognition)
 


### PR DESCRIPTION
## Summary
- support the Cursor editor in Visual Studio Code rules
- document Cursor in README and command reference

## Testing
- `python tests/testrunner.py` *(fails: ModuleNotFoundError: No module named 'dragonfly')*