### PR TITLE
Switch to Python 3.11

### DIFF
--- a/.github/workflows/testrunner.yml
+++ b/.github/workflows/testrunner.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: windows-latest
         strategy:
           matrix:
-            python-version: [3.10.x]
+            python-version: [3.11.x]
         steps:
           - uses: actions/checkout@v2
           - name: Set up Python
@@ -34,7 +34,7 @@ jobs:
         runs-on: ubuntu-20.04
         strategy:
           matrix:
-            python-version: [3.10.x]
+            python-version: [3.11.x]
         steps:
           - uses: actions/checkout@v2
           - name: Set up Python
@@ -63,7 +63,7 @@ jobs:
         runs-on: macos-latest
         strategy:
           matrix:
-            python-version: [3.10.x]
+            python-version: [3.11.x]
         steps:
           - uses: actions/checkout@v2
           - name: Set up Python

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Guidelines for Automated Contributions
+
+This repository is a Python project built around the Caster voice toolkit. Use these instructions when proposing or modifying code.
+
+## Coding Style
+
+- Format all Python code with `yapf` using the configuration in `.style.yapf` which specifies a PEP8 base style and a `column_limit` of 90 characters.
+- Lint with `pylint` using the provided `.pylintrc`. Only error level checks are enabled.
+
+## Tests
+
+- Run the unit tests through `python tests/testrunner.py`.
+- The CI workflow also runs `pylint -E` on `_caster.py` and the `castervoice` package.
+- Ensure tests pass on Python 3.11, as referenced in the GitHub Actions workflow.
+
+## Documentation
+
+- Documentation lives in the `docs/` directory and is built with MkDocs. New documentation pages should be added as Markdown files under `docs/` or its subdirectories.
+- For feature documentation, see `docs/readthedocs/meta/GRAMMAR_DOCUMENTATION_TEMPLATE.md` for a template.
+
+## Adding New Rules
+
+- Place new language or application rules inside the `castervoice/rules` directory in the appropriate category.
+
+## Pull Requests
+
+- Follow the PR template in `.github/pull_request_template.md` when submitting changes.
+- For significant contributions, open an issue first to discuss your plans with the community.
+
+

--- a/Install_Caster_DNS-WSR.bat
+++ b/Install_Caster_DNS-WSR.bat
@@ -2,7 +2,7 @@
 @echo off
 
 SetLocal EnableDelayedExpansion
-set python_version=3.10-32
+set python_version=3.11-32
 set currentpath=%~dp0
 echo Installation path: %currentpath%
 


### PR DESCRIPTION
## Summary
- mention Python 3.11 requirement in AGENTS instructions
- update GitHub Actions to use Python 3.11
- bump the installer script to Python 3.11

## Testing
- `python tests/testrunner.py`
- `pylint -E _caster.py castervoice`