### PR TITLE
Document OpenAI utilities

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -87,6 +87,7 @@
   - [Sikulix](http://sikulix.com/) - [Setup](https://caster.readthedocs.io/en/latest/readthedocs/Third-party_Integrations/Sikuli/): Automates anything you see on the screen of your desktop computer. - [Demo](https://youtu.be/RFdsD2OgDzk?list=PLV6JPhkq1x8LHu02YefhUU9rXiB2PK8tc&t=512)
   - [Aenea](https://github.com/dictation-toolbox/aenea) - [Setup](https://caster.readthedocs.io/en/latest/readthedocs/Third-party_Integrations/Aenea/): A client-server library for using voice macros from Dragon NaturallySpeaking and Dragonfly on remote/non-windows hosts.
   - [Autohotkey](https://www.autohotkey.com/): A scripting language that allows the automation of various tasks in Windows. Simply install the latest version. If installed, it can speed up some commands by a few seconds - e.g. [checking out or updating a pull request from github](https://caster.readthedocs.io/en/latest/readthedocs/Caster_Commands/Application_Commands_Quick_Reference/#google-chrome).
+  - OpenAI Dictation - [Setup](https://caster.readthedocs.io/en/latest/readthedocs/Third-party_Integrations/OpenAI/): Experimental support for transcribing and refining speech using OpenAI services.
 
 - Caster extends the Dragonfly API for even more powerful commands.
 

--- a/docs/readthedocs/Third-party_Integrations/OpenAI.md
+++ b/docs/readthedocs/Third-party_Integrations/OpenAI.md
@@ -1,0 +1,18 @@
+# OpenAI Dictation Integration
+
+Caster includes optional modules for leveraging OpenAI services to transcribe and refine dictated text. The two modules are:
+
+- `castervoice.lib.openai_utils` – wraps the `openai` Python package and exposes helper methods for Whisper transcription and GPT based text refinement.
+- `castervoice.lib.openai_recorder` – records audio from the microphone, uses `openai_utils` to process it and pastes the results back into the active application.
+
+## Configuration
+
+1. Install the `openai` Python package (already included in `requirements.txt`).
+2. Provide your OpenAI API key via the `OPENAI_API_KEY` environment variable so that `OpenAIUtils` can authenticate.
+3. Load the `openai_dictation_rules` rule and issue the voice command `dictate` to start recording. Use `append`, `edit` and `dictate off` to control processing.
+
+## Privacy considerations
+
+When this feature is enabled, captured audio and text are sent to OpenAI servers for transcription and language‑model processing. This may include sensitive information. Review OpenAI's terms and privacy policy before using the feature and disable it if you are uncomfortable sending data to third‑party services.
+
+This functionality is experimental and disabled by default. Only enable it if you have configured an API key and understand the privacy implications.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
     - Third-party Integrations:
         - 'Aenea':  readthedocs/Third-party_Integrations/Aenea.md
         - 'Sikuli': readthedocs/Third-party_Integrations/Sikuli.md
+        - 'OpenAI Dictation': readthedocs/Third-party_Integrations/OpenAI.md
     - Contributing: Contributing.md
     - Code of Conduct: CODE_OF_CONDUCT.md
     - License: LICENSE.md


### PR DESCRIPTION
## Summary
- add OpenAI dictation page
- link new page from docs
- update documentation index

## Testing
- `python -m py_compile $(git ls-files '*.py')`