### PR TITLE
Use unittest.mock and drop mock dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ wxpython
 pillow>=6.2.2
 tomlkit>=0.11.8
 future>=0.18.2
-mock>=3.0.5
 appdirs>=1.4.3
 scandir>=1.10.0
 pylint

--- a/requirements-mac-linux.txt
+++ b/requirements-mac-linux.txt
@@ -2,7 +2,6 @@ dragonfly2[kaldi]>=0.34.0
 pillow>=8.0.0
 tomlkit>=0.11.8
 future>=0.18.2
-mock>=3.0.5
 appdirs>=1.4.3
 scandir>=1.10.0
 pylint

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ wxpython
 pillow>=6.2.2
 tomlkit>=0.11.8
 future>=0.18.2
-mock>=3.0.5
 appdirs>=1.4.3
 scandir>=1.10.0
 pyvda==0.0.8

--- a/tests/lib/ctrl/mgr/loading/load/test_contentLoader.py
+++ b/tests/lib/ctrl/mgr/loading/load/test_contentLoader.py
@@ -1,5 +1,5 @@
 import os
-from mock import Mock
+from unittest.mock import Mock
 from castervoice.lib.ctrl.mgr.loading.load import content_loader
 from castervoice.lib.ctrl.mgr.loading.load.content_request import ContentRequest
 from castervoice.lib.ctrl.mgr.loading.load.content_request_generator import ContentRequestGenerator

--- a/tests/lib/ctrl/mgr/loading/load/test_contentRequestGenerator.py
+++ b/tests/lib/ctrl/mgr/loading/load/test_contentRequestGenerator.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mock import Mock
+from unittest.mock import Mock
 
 from castervoice.lib.ctrl.mgr.loading.load.content_request_generator import ContentRequestGenerator
 from castervoice.lib.ctrl.mgr.loading.load.content_type import ContentType

--- a/tests/lib/ctrl/mgr/test_grammarManager.py
+++ b/tests/lib/ctrl/mgr/test_grammarManager.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 
 from castervoice.lib.ctrl.mgr.loading.load.initial_content import FullContentSet
 from tests.test_util import settings_mocking

--- a/tests/lib/ctrl/test_grammarContainer.py
+++ b/tests/lib/ctrl/test_grammarContainer.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mock import Mock
+from unittest.mock import Mock
 
 from castervoice.lib.ctrl.mgr.grammar_container.basic_grammar_container import BasicGrammarContainer
 

--- a/tests/lib/merge/ccrmerging2/test_CCRMerger2.py
+++ b/tests/lib/merge/ccrmerging2/test_CCRMerger2.py
@@ -1,7 +1,7 @@
 from itertools import permutations
 
 from dragonfly.grammar.context import LogicNotContext, Context, LogicAndContext,FuncContext
-from mock import Mock
+from unittest.mock import Mock
 from castervoice.lib.context import AppContext
 from castervoice.rules.apps.editor.eclipse_rules.eclipse import EclipseCCR
 from castervoice.rules.apps.editor.vscode_rules.vscode import VSCodeCcrRule

--- a/tests/test_util/settings_mocking.py
+++ b/tests/test_util/settings_mocking.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mock import Mock
+from unittest.mock import Mock
 
 from castervoice.lib import settings
 


### PR DESCRIPTION
## Summary
- update tests to import `Mock` from `unittest.mock`
- remove `mock` from all requirements files

## Testing
- `python tests/testrunner.py`