### PR TITLE
Refactor Qt imports to use compatibility layer and update requirements for PySide6 on macOS. Adjust event handling and UI components in HUD and settings windows to utilize new Qt attributes. Ensure consistent application execution method across modules.

### DIFF
--- a/.github/workflows/testrunner.yml
+++ b/.github/workflows/testrunner.yml
@@ -31,7 +31,7 @@ jobs:
 
   python-linux-3-10-x:
         name: python 3 linux
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         strategy:
           matrix:
             python-version: [3.10.x]

--- a/castervoice/asynch/hmc/h_launch.py
+++ b/castervoice/asynch/hmc/h_launch.py
@@ -52,17 +52,17 @@ def _get_title(hmc_type):
 
 
 def main():
-    import PySide2.QtWidgets
+    from castervoice.lib.qt import QtWidgets, qapp_exec
     from castervoice.asynch.hmc.homunculus import Homunculus
     from castervoice.lib.merge.communication import Communicator
     server_address = (Communicator.LOCALHOST, Communicator().com_registry["hmc"])
     # Enabled by default logging causes RPC to malfunction when the GUI runs on
     # pythonw.  Explicitly disable logging for the XML server.
     server = SimpleXMLRPCServer(server_address, logRequests=False, allow_none=True)
-    app = PySide2.QtWidgets.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = Homunculus(server, sys.argv)
     window.show()
-    exit_code = app.exec_()
+    exit_code = qapp_exec(app)
     server.shutdown()
     sys.exit(exit_code)
 

--- a/castervoice/asynch/hmc/homunculus.py
+++ b/castervoice/asynch/hmc/homunculus.py
@@ -4,23 +4,6 @@ import threading
 
 import dragonfly
 
-# TODO: Remove this try wrapper when CI server supports Qt
-try:
-    import PySide2.QtCore
-    from PySide2.QtWidgets import QApplication
-    from PySide2.QtWidgets import QCheckBox
-    from PySide2.QtWidgets import QDialog
-    from PySide2.QtWidgets import QFileDialog
-    from PySide2.QtWidgets import QFormLayout
-    from PySide2.QtWidgets import QLabel
-    from PySide2.QtWidgets import QLineEdit
-    from PySide2.QtWidgets import QScrollArea
-    from PySide2.QtWidgets import QTextEdit
-    from PySide2.QtWidgets import QVBoxLayout
-    from PySide2.QtWidgets import QWidget
-except ImportError:
-    sys.exit(0)
-
 try:  # Style C -- may be imported into Caster, or externally
     BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "castervoice", 1)[0]
     if BASE_PATH not in sys.path:
@@ -28,7 +11,31 @@ try:  # Style C -- may be imported into Caster, or externally
 finally:
     from castervoice.lib import settings
 
-RPC_DIR_EVENT = PySide2.QtCore.QEvent.Type(PySide2.QtCore.QEvent.registerEventType(-1))
+try:
+    from castervoice.lib.qt import QtCore, QtWidgets, qt_attr
+except ImportError:
+    sys.exit(0)
+
+QApplication = QtWidgets.QApplication
+QCheckBox = QtWidgets.QCheckBox
+QDialog = QtWidgets.QDialog
+QFileDialog = QtWidgets.QFileDialog
+QFormLayout = QtWidgets.QFormLayout
+QLabel = QtWidgets.QLabel
+QLineEdit = QtWidgets.QLineEdit
+QScrollArea = QtWidgets.QScrollArea
+QTextEdit = QtWidgets.QTextEdit
+QVBoxLayout = QtWidgets.QVBoxLayout
+QWidget = QtWidgets.QWidget
+
+ALIGN_CENTER = qt_attr(QtCore, ("Qt", "AlignCenter"), ("Qt", "AlignmentFlag", "AlignCenter"))
+SHOW_DIRS_ONLY = qt_attr(
+    QtWidgets,
+    ("QFileDialog", "ShowDirsOnly"),
+    ("QFileDialog", "Option", "ShowDirsOnly"),
+)
+
+RPC_DIR_EVENT = QtCore.QEvent.Type(QtCore.QEvent.registerEventType(-1))
 
 
 class Homunculus(QDialog):
@@ -64,7 +71,7 @@ class Homunculus(QDialog):
         self.setWindowTitle(settings.HOMUNCULUS_VERSION)
         self.data = data.split("|") if data else [0, 0]
         label = QLabel(" ".join(self.data[0].split(settings.HMC_SEPARATOR))) if data else QLabel("Enter response then say 'complete'")  # pylint: disable=no-member
-        label.setAlignment(PySide2.QtCore.Qt.AlignCenter)
+        label.setAlignment(ALIGN_CENTER)
         self.ext_box = QTextEdit()
         self.mainLayout.addWidget(label)
         self.mainLayout.addWidget(self.ext_box)
@@ -98,7 +105,7 @@ class Homunculus(QDialog):
         self.setGeometry(x, y, 640, 480)
         self.setWindowTitle(settings.HOMUNCULUS_VERSION + settings.HMC_TITLE_RECORDING)
         label = QLabel("Macro Recording Options")
-        label.setAlignment(PySide2.QtCore.Qt.AlignCenter)
+        label.setAlignment(ALIGN_CENTER)
         self.mainLayout.addWidget(label)
         label = QLabel("Command Words:")
         self.word_box = QLineEdit()
@@ -108,7 +115,7 @@ class Homunculus(QDialog):
         self.repeatable = QCheckBox("Make Repeatable")
         self.mainLayout.addWidget(self.repeatable)
         label = QLabel("Dictation History")
-        label.setAlignment(PySide2.QtCore.Qt.AlignCenter)
+        label.setAlignment(ALIGN_CENTER)
         self.mainLayout.addWidget(label)
         self.word_state = []
         cb_number = 1
@@ -144,7 +151,7 @@ class Homunculus(QDialog):
             self.word_state[i].setChecked(True)
 
     def ask_directory(self):
-        result = QFileDialog.getExistingDirectory(self, "Please select directory", os.environ["HOME"], QFileDialog.ShowDirsOnly)
+        result = QFileDialog.getExistingDirectory(self, "Please select directory", os.environ["HOME"], SHOW_DIRS_ONLY)
         self.word_box.setText(result)
 
     def event(self, event):
@@ -214,7 +221,7 @@ class Homunculus(QDialog):
 
     def xmlrpc_do_action_directory(self, action, details=None):
         if action == "dir":
-            PySide2.QtCore.QCoreApplication.postEvent(self, PySide2.QtCore.QEvent(RPC_DIR_EVENT))
+            QtCore.QCoreApplication.postEvent(self, QtCore.QEvent(RPC_DIR_EVENT))
 
     def xmlrpc_get_message_directory(self):
         response = None

--- a/castervoice/asynch/settingswindow.py
+++ b/castervoice/asynch/settingswindow.py
@@ -14,20 +14,21 @@ finally:
     from castervoice.lib import settings
     from castervoice.lib.merge.communication import Communicator
 
-from PySide2 import QtCore
-from PySide2.QtGui import QPalette
-from PySide2.QtWidgets import QApplication
-from PySide2.QtWidgets import QDialogButtonBox
-from PySide2.QtWidgets import QCheckBox
-from PySide2.QtWidgets import QDialog
-from PySide2.QtWidgets import QFormLayout
-from PySide2.QtWidgets import QGroupBox
-from PySide2.QtWidgets import QLabel
-from PySide2.QtWidgets import QLineEdit
-from PySide2.QtWidgets import QScrollArea
-from PySide2.QtWidgets import QTabWidget
-from PySide2.QtWidgets import QVBoxLayout
-from PySide2.QtWidgets import QWidget
+from castervoice.lib.qt import QtCore, QtGui, QtWidgets, qt_attr, qapp_exec
+
+QPalette = QtGui.QPalette
+QApplication = QtWidgets.QApplication
+QDialogButtonBox = QtWidgets.QDialogButtonBox
+QCheckBox = QtWidgets.QCheckBox
+QDialog = QtWidgets.QDialog
+QFormLayout = QtWidgets.QFormLayout
+QGroupBox = QtWidgets.QGroupBox
+QLabel = QtWidgets.QLabel
+QLineEdit = QtWidgets.QLineEdit
+QScrollArea = QtWidgets.QScrollArea
+QTabWidget = QtWidgets.QTabWidget
+QVBoxLayout = QtWidgets.QVBoxLayout
+QWidget = QtWidgets.QWidget
 
 
 
@@ -39,8 +40,21 @@ NUMBER_LIST_SETTING = 8
 NUMBER_SETTING = 16
 BOOLEAN_SETTING = 32
 
-CONTROL_KEY = QtCore.Qt.Key_Meta if sys.platform == "darwin" else QtCore.Qt.Key_Control
-SHIFT_TAB_KEY = int(QtCore.Qt.Key_Tab) + 1
+KEY_META = qt_attr(QtCore, ("Qt", "Key_Meta"), ("Qt", "Key", "Key_Meta"))
+KEY_CONTROL = qt_attr(QtCore, ("Qt", "Key_Control"), ("Qt", "Key", "Key_Control"))
+KEY_TAB = qt_attr(QtCore, ("Qt", "Key_Tab"), ("Qt", "Key", "Key_Tab"))
+
+CONTROL_KEY = int(KEY_META if sys.platform == "darwin" else KEY_CONTROL)
+TAB_KEY = int(KEY_TAB)
+SHIFT_TAB_KEY = TAB_KEY + 1
+
+KEY_RELEASE_EVENT = qt_attr(QtCore, ("QEvent", "KeyRelease"), ("QEvent", "Type", "KeyRelease"))
+PALETTE_MID = qt_attr(QtGui, ("QPalette", "Mid"), ("QPalette", "ColorRole", "Mid"))
+FORM_GROW_ALL_NON_FIXED = qt_attr(
+    QtWidgets,
+    ("QFormLayout", "AllNonFixedFieldsGrow"),
+    ("QFormLayout", "FieldGrowthPolicy", "AllNonFixedFieldsGrow"),
+)
 
 RPC_COMPLETE_EVENT = QtCore.QEvent.Type(QtCore.QEvent.registerEventType(-1))
 
@@ -83,11 +97,11 @@ class SettingsDialog(QDialog):
         self.expiration.start()
 
     def event(self, event):
-        if event.type() == QtCore.QEvent.KeyRelease:
+        if event.type() == KEY_RELEASE_EVENT:
             if self.modifier == 1:
                 curr = self.tabs.currentIndex()
                 tabs_count = self.tabs.count()
-                if event.key() == QtCore.Qt.Key_Tab:
+                if event.key() == TAB_KEY:
                     next = curr + 1
                     next = 0 if next == tabs_count else next
                     self.tabs.setCurrentIndex(next)
@@ -116,7 +130,7 @@ class SettingsDialog(QDialog):
     def make_tab(self, title):
         area = QScrollArea()
         field = Field(area, title)
-        area.setBackgroundRole(QPalette.Mid)
+        area.setBackgroundRole(PALETTE_MID)
         area.setWidgetResizable(True)
         area.setWidget(self.add_fields(self, title, field))
         self.fields.append(field)
@@ -125,7 +139,7 @@ class SettingsDialog(QDialog):
     def add_fields(self, parent, title, field):
         tab = QWidget(parent)
         form = QFormLayout()
-        form.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
+        form.setFieldGrowthPolicy(FORM_GROW_ALL_NON_FIXED)
         for label in sorted(settings.SETTINGS[title].keys()):
             value = settings.SETTINGS[title][label]
             subfield = Field(None, label)
@@ -233,7 +247,7 @@ def main():
     app = QApplication(sys.argv)
     window = SettingsDialog(server)
     window.show()
-    exit_code = app.exec_()
+    exit_code = qapp_exec(app)
     server.shutdown()
     sys.exit(exit_code)
 

--- a/castervoice/lib/qt.py
+++ b/castervoice/lib/qt.py
@@ -1,0 +1,41 @@
+# pylint: disable=import-error,no-name-in-module
+
+"""
+Minimal PySide2/PySide6 compatibility helpers.
+"""
+
+
+try:
+    from PySide2 import QtCore, QtGui, QtWidgets  # type: ignore
+    QT_API = "PySide2"
+except ImportError:  # pragma: no cover
+    from PySide6 import QtCore, QtGui, QtWidgets  # type: ignore
+    QT_API = "PySide6"
+
+
+def qt_attr(root, *paths):
+    """
+    Return the first attribute path that exists on `root`.
+
+    `paths` should be tuples of attribute names, e.g. ("Qt", "Key", "Key_Tab").
+    """
+    last_error = None
+    for path in paths:
+        try:
+            obj = root
+            for name in path:
+                obj = getattr(obj, name)
+            return obj
+        except AttributeError as exc:
+            last_error = exc
+    if last_error is None:
+        raise AttributeError("qt_attr() requires at least one path")
+    raise last_error
+
+
+def qapp_exec(app):
+    exec_fn = getattr(app, "exec", None) or getattr(app, "exec_", None)
+    if exec_fn is None:
+        raise AttributeError("QApplication has no exec/exec_ method")
+    return exec_fn()
+

--- a/requirements-mac-linux.txt
+++ b/requirements-mac-linux.txt
@@ -6,6 +6,7 @@ mock>=3.0.5
 appdirs>=1.4.3
 scandir>=1.10.0
 pylint
-PySide2>=5.14
+PySide6>=6.5; platform_system == "Darwin"
+PySide2>=5.14; platform_system != "Darwin"
 six
 g2p_en

--- a/requirements-mac-linux.txt
+++ b/requirements-mac-linux.txt
@@ -1,4 +1,5 @@
-dragonfly2[kaldi]>=0.34.0
+dragonfly2>=0.34.0; platform_system == "Darwin"
+dragonfly2[kaldi]>=0.34.0; platform_system == "Linux"
 pillow>=8.0.0
 tomlkit>=0.11.8
 future>=0.18.2


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Modernizes Qt integration and platform support.
> 
> - Introduces `castervoice/lib/qt.py` with `QtCore/QtGui/QtWidgets`, `qt_attr`, and `qapp_exec` for PySide2/PySide6 compatibility
> - Refactors `h_launch.py`, `homunculus.py`, `hud.py`, and `settingswindow.py` to import from `castervoice.lib.qt`, replace enum/flag usages with `qt_attr`, and use `qapp_exec`
> - Updates `requirements-mac-linux.txt` to install `PySide6` on macOS and `PySide2` elsewhere; splits `dragonfly2` vs `dragonfly2[kaldi]` by platform
> - CI: switch Linux runners to `ubuntu-latest` and ensure GTK/Tk dev packages are installed before installing mac/linux requirements
> - Adds `natlink` import guards and no-op messaging in `engine_manager.py` for non-Natlink environments; early-return in `_sync_mode`
> - Minor robustness in text manipulation support: validate inputs, use lowered text once, and simplify offset calculations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc86995c9fda20afe159543ba38f76b746e41e49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->