### PR TITLE
Guard clear_log() against missing status windows

### DIFF
--- a/castervoice/lib/utilities.py
+++ b/castervoice/lib/utilities.py
@@ -248,6 +248,7 @@ def clear_log():
     # Natlink status window not used in out-of-process mode.
     # TODO: window_exists utilized when engine launched through Dragonfly CLI via bat in future
     try:
+        window_title = "Caster: Status Window"
         if WIN32:
             clearcmd = "cls"  # Windows OS
         else:
@@ -256,15 +257,20 @@ def clear_log():
             from natlinkcore import natlinkstatus # pylint: disable=import-error
             status = natlinkstatus.NatlinkStatus()
             if status.NatlinkIsEnabled() == 1:
+                window_title = "Messages from Natlink"
                 import win32gui  # pylint: disable=import-error
-                handle = get_window_by_title("Messages from Python Macros") or get_window_by_title("Messages from Natlink")
-                rt_handle = win32gui.FindWindowEx(handle, None, "RICHEDIT", None)
-                win32gui.SetWindowText(rt_handle, "")
+                handle = get_window_by_title("Messages from Python Macros")
+                if not handle:
+                    handle = get_window_by_title(window_title)
+                if handle:
+                    rt_handle = win32gui.FindWindowEx(handle, None, "RICHEDIT", None)
+                    if rt_handle:
+                        win32gui.SetWindowText(rt_handle, "")
             else:
-                if window_exists(windowname="Caster: Status Window"):
+                if window_exists(windowname=window_title):
                     os.system(clearcmd)
         else:
-            if window_exists(windowname="Caster: Status Window"):
+            if window_exists(windowname=window_title):
                 os.system(clearcmd)
             else:
                 printer.out("clear_log: Not implemented with GUI")


### PR DESCRIPTION
## Description

This change makes `clear_log()` safer when clearing the Caster/Natlink status window.

It keeps the status window title in one local variable inside `clear_log()`, and it only calls `FindWindowEx` / `SetWindowText` when the expected parent window and `RICHEDIT` child control are actually present.

## Related Issue

None.

## Motivation and Context

This change is required because `clear_log()` currently assumes that the Natlink in-process status window always exists and always contains the expected `RICHEDIT` control.

In the current code, when Natlink is enabled in-process, `clear_log()`:

- looks up `"Messages from Python Macros"` or `"Messages from Natlink"`
- immediately passes the result into `FindWindowEx`
- immediately passes the result of that into `SetWindowText`

That is fragile.

Example 1:

- Natlink is enabled in-process.
- Neither `"Messages from Python Macros"` nor `"Messages from Natlink"` is currently open.
- `get_window_by_title(...)` returns `0`.
- `clear_log()` still proceeds with the Win32 calls instead of bailing out safely.

Example 2:

- The parent status window exists.
- The expected `RICHEDIT` child control does not exist.
- `clear_log()` still attempts to write to that missing control.

This patch fixes that by guarding both lookups before calling `SetWindowText`.

## How Has This Been Tested

I have not functionally tested this in a Natlink in-process Windows environment.

I verified the following locally in the project `.venv`:

- Installed Dragonfly into `.venv` from `../dragonfly`
- `.venv/bin/python -m py_compile castervoice/lib/utilities.py`
- `.venv/bin/pylint -E castervoice/lib/utilities.py`
- `.venv/bin/python tests/testrunner.py`

I also confirmed that the diff is limited to `clear_log()` in `castervoice/lib/utilities.py`.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small defensive change limited to `clear_log()` to avoid Win32 calls when expected windows/controls are missing.
> 
> **Overview**
> Makes `clear_log()` more defensive when clearing Natlink/Caster status output.
> 
> It centralizes the target window title in a local `window_title` variable and only calls `win32gui.FindWindowEx`/`SetWindowText` after confirming the parent window handle and `RICHEDIT` child control exist, avoiding crashes when the Natlink status window is not open.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92b7e756bf3b3f24a05977f72d749bb85533c367. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->