### PR TITLE
Fix bring me transformer file default path

### DIFF
--- a/castervoice/rules/ccr/recording_rules/bringme.py
+++ b/castervoice/rules/ccr/recording_rules/bringme.py
@@ -245,7 +245,7 @@ class BringRule(BaseSelfModifyingRule):
             "caster log file": str(Path(_user_dir).joinpath("log.txt")),
 
             # Simplified Transformer
-            "caster transformer file": settings.settings(["paths", "GDEF_FILE"]),
+            "caster transformer file": str(Path(_user_dir).joinpath(ContentRoot.USER_DIR).joinpath("transformers/words.txt")),
         }
     }
 

--- a/castervoice/rules/ccr/recording_rules/bringme.py
+++ b/castervoice/rules/ccr/recording_rules/bringme.py
@@ -245,7 +245,7 @@ class BringRule(BaseSelfModifyingRule):
             "caster log file": str(Path(_user_dir).joinpath("log.txt")),
 
             # Simplified Transformer
-            "caster transformer file": str(Path(_user_dir).joinpath("transformers/words.txt")),
+            "caster transformer file": settings.settings(["paths", "GDEF_FILE"]),
         }
     }
 


### PR DESCRIPTION
## Summary
- point the default `bring me caster transformer file` entry at the canonical transformer file path
- use the existing `paths.GDEF_FILE` setting so the bring-me default stays aligned with the runtime loader

## Testing
- not run (one-line path fix)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk one-line default-path change that only affects the initial `bring me` defaults; existing user configs are unchanged.
> 
> **Overview**
> Updates the `bring me` default entry for `caster transformer file` to point at the canonical user-content transformer location by including `ContentRoot.USER_DIR` (i.e., `USER_DIR/USER_DIR/transformers/words.txt`), keeping it aligned with how user content is organized/loaded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 365df3264d9610c6e61944956486e187a11c204f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->