### PR TITLE
Fix bring-me transformer file path

### DIFF
--- a/castervoice/rules/ccr/recording_rules/bringme.py
+++ b/castervoice/rules/ccr/recording_rules/bringme.py
@@ -245,7 +245,7 @@ class BringRule(BaseSelfModifyingRule):
             "caster log file": str(Path(_user_dir).joinpath("log.txt")),
 
             # Simplified Transformer
-            "caster transformer file": str(Path(_user_dir).joinpath("transformers/words.txt")),
+            "caster transformer file": str(Path(_user_dir).joinpath(ContentRoot.USER_DIR).joinpath("transformers/words.txt")),
         }
     }
 


### PR DESCRIPTION
## Description

Correct the default `bring me` entry for the simplified transformer file so it points to `caster_user_content/transformers/words.txt` instead of the legacy top-level `transformers/words.txt` path.

## Related Issue

N/A

## Motivation and Context

The default `caster transformer file` bring-me target points to a path that does not match the runtime loader or documented user-directory layout. This can send users to a non-existent file even when the real `words.txt` exists in the expected location.

## How Has This Been Tested

Used the project `.venv` to instantiate `BringRule()` with mocked TOML storage and minimal mocked settings, confirming the rule still instantiates with the corrected path.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

- [ ] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [ ] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single default path string change that only affects the initial `bring me` defaults and does not alter execution logic.
> 
> **Overview**
> Updates the `bring me` default target for `caster transformer file` to use the `caster_user_content/transformers/words.txt` path under `USER_DIR` (via `ContentRoot.USER_DIR`), instead of the legacy top-level `transformers/words.txt` location.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 271c5050969133145e9aae144939d4af11fd946a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->