### PR TITLE
[codex] Runtime launch and user-dir fixes

### DIFF
--- a/castervoice/asynch/hmc/h_launch.py
+++ b/castervoice/asynch/hmc/h_launch.py
@@ -26,12 +26,12 @@ def launch(hmc_type, data=None):
 def _get_instructions(hmc_type):
     if hmc_type == settings.QTTYPE_SETTINGS:
         return [
-            settings.SETTINGS["paths"]["PYTHONW"],
+            settings.runtime_hidden_console_binary(),
             settings.SETTINGS["paths"]["SETTINGS_WINDOW_PATH"]
         ]
     else:
         return [
-            settings.SETTINGS["paths"]["PYTHONW"],
+            settings.runtime_hidden_console_binary(),
             settings.SETTINGS["paths"]["HOMUNCULUS_PATH"], hmc_type
         ]
 

--- a/castervoice/asynch/hud_support.py
+++ b/castervoice/asynch/hud_support.py
@@ -19,7 +19,7 @@ def start_hud():
     try:
         hud.ping()
     except Exception:
-        subprocess.Popen([settings.SETTINGS["paths"]["PYTHONW"],
+        subprocess.Popen([settings.runtime_hidden_console_binary(),
                           settings.SETTINGS["paths"]["HUD_PATH"]])
 
 

--- a/castervoice/lib/navigation.py
+++ b/castervoice/lib/navigation.py
@@ -73,25 +73,25 @@ class Grid:
             ls.scan(bbox, rough)
             tscan = ls.get_update()
             args = [
-                settings.settings(["paths", "PYTHONW"]),
+                settings.runtime_hidden_console_binary(),
                 settings.settings(["paths", "LEGION_PATH"]), "-t", tscan[0], "-m",
                 str(monitor)
             ]
         elif mode == "rainbow":
             args = [
-                settings.settings(["paths", "PYTHONW"]),
+                settings.runtime_hidden_console_binary(),
                 settings.settings(["paths", "RAINBOW_PATH"]), "-g", "r", "-m",
                 str(monitor)
             ]
         elif mode == "douglas":
             args = [
-                settings.settings(["paths", "PYTHONW"]),
+                settings.runtime_hidden_console_binary(),
                 settings.settings(["paths", "DOUGLAS_PATH"]), "-g", "d", "-m",
                 str(monitor)
             ]
         elif mode == "sudoku":
             args = [
-                settings.settings(["paths", "PYTHONW"]),
+                settings.runtime_hidden_console_binary(),
                 settings.settings(["paths", "SUDOKU_PATH"]), "-g", "s", "-m",
                 str(monitor)
             ]

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -107,9 +107,6 @@ def runtime_hidden_console_binary():
         runtime_binary = SYSTEM_INFORMATION.get("hidden console binary", "")
     if runtime_binary and os.path.isfile(runtime_binary):
         return runtime_binary
-    configured_binary = settings(["paths", "PYTHONW"], "")
-    if configured_binary and os.path.isfile(configured_binary):
-        return configured_binary
     return _hidden_console_binary_for(sys.executable)
 
 
@@ -354,9 +351,6 @@ def _get_defaults():
             "CONFIGDEBUGTXT_PATH":
                 str(Path(_USER_DIR).joinpath("data/configdebug.txt")),
 
-            # PYTHON
-            "PYTHONW":
-                SYSTEM_INFORMATION["hidden console binary"],
         },
 
         # Speech recognition engine settings

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -42,7 +42,6 @@ SYSTEM_INFORMATION = None
 WSR = False
 _BASE_PATH = None
 _USER_DIR = None
-_USER_DIR_REPORTED = False
 _SETTINGS_PATH = None
 
 
@@ -89,16 +88,6 @@ def detected_user_dir():
     if configured_user_dir is not None:
         return configured_user_dir
     return user_data_dir(appname="caster", appauthor=False)
-
-
-def report_user_dir():
-    global _USER_DIR, _USER_DIR_REPORTED
-    if _USER_DIR is None:
-        _USER_DIR = detected_user_dir()
-    if not _USER_DIR_REPORTED:
-        printer.out("Caster User Directory: {}".format(_USER_DIR))
-        _USER_DIR_REPORTED = True
-    return _USER_DIR
 
 
 def runtime_hidden_console_binary():
@@ -519,4 +508,4 @@ def initialize():
     if _debugger_path not in sys.path and os.path.isdir(_debugger_path):
         sys.path.append(_debugger_path)
 
-    report_user_dir()
+    printer.out("Caster User Directory: {}".format(_USER_DIR))

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -42,7 +42,20 @@ SYSTEM_INFORMATION = None
 WSR = False
 _BASE_PATH = None
 _USER_DIR = None
+_USER_DIR_REPORTED = False
 _SETTINGS_PATH = None
+
+
+def _hidden_console_binary_for(executable):
+    executable_path = Path(executable)
+    if sys.platform != "win32":
+        return str(executable_path)
+    if executable_path.name.lower() == "pythonw.exe":
+        return str(executable_path)
+    hidden_console_binary = executable_path.with_name("pythonw.exe")
+    if hidden_console_binary.is_file():
+        return str(hidden_console_binary)
+    return str(executable_path)
 
 
 def _get_platform_information():
@@ -51,17 +64,15 @@ def _get_platform_information():
     system_information = {"platform": sysconfig.get_platform()}
     system_information.update({"python version": sys.version_info})
     binary_path = str(Path(sys.exec_prefix).joinpath(sys.exec_prefix).joinpath("bin"))
-    hidden_console_binary = str(Path(sys.executable))
     main_binary = str(Path(sys.executable))
     if sys.platform == "win32":
         if sys.prefix == sys.base_prefix:
             main_binary = str(Path(sys.exec_prefix).joinpath("python.exe"))
-            hidden_console_binary = str(Path(sys.exec_prefix).joinpath("pythonw.exe"))
         else:
             # Virtual environment detected
             # TODO: MacOS and Linux?
             main_binary = str(Path(sys.prefix) / "Scripts" / "python.exe")
-            hidden_console_binary = str(Path(sys.prefix) / "Scripts" / "pythonw.exe")
+    hidden_console_binary = _hidden_console_binary_for(main_binary)
     system_information.update({"binary path": binary_path})
     system_information.update({"main binary": main_binary})
     system_information.update({"hidden console binary": hidden_console_binary})
@@ -71,6 +82,35 @@ def _get_platform_information():
 
 def get_filename():
     return _SETTINGS_PATH
+
+
+def detected_user_dir():
+    configured_user_dir = os.getenv("CASTER_USER_DIR")
+    if configured_user_dir is not None:
+        return configured_user_dir
+    return user_data_dir(appname="caster", appauthor=False)
+
+
+def report_user_dir():
+    global _USER_DIR, _USER_DIR_REPORTED
+    if _USER_DIR is None:
+        _USER_DIR = detected_user_dir()
+    if not _USER_DIR_REPORTED:
+        printer.out("Caster User Directory: {}".format(_USER_DIR))
+        _USER_DIR_REPORTED = True
+    return _USER_DIR
+
+
+def runtime_hidden_console_binary():
+    runtime_binary = ""
+    if SYSTEM_INFORMATION is not None:
+        runtime_binary = SYSTEM_INFORMATION.get("hidden console binary", "")
+    if runtime_binary and os.path.isfile(runtime_binary):
+        return runtime_binary
+    configured_binary = settings(["paths", "PYTHONW"], "")
+    if configured_binary and os.path.isfile(configured_binary):
+        return configured_binary
+    return _hidden_console_binary_for(sys.executable)
 
 
 def _validate_engine_path():
@@ -471,10 +511,7 @@ def initialize():
     # calculate prerequisites
     SYSTEM_INFORMATION = _get_platform_information()
     _BASE_PATH = str(Path(__file__).resolve().parent.parent)
-    if os.getenv("CASTER_USER_DIR") is not None:
-        _USER_DIR = os.getenv("CASTER_USER_DIR")
-    else:
-        _USER_DIR = user_data_dir(appname="caster", appauthor=False)
+    _USER_DIR = detected_user_dir()
     _SETTINGS_PATH = str(Path(_USER_DIR).joinpath("settings/settings.toml"))
 
     # Kick everything off.
@@ -488,4 +525,4 @@ def initialize():
     if _debugger_path not in sys.path and os.path.isdir(_debugger_path):
         sys.path.append(_debugger_path)
 
-    printer.out("Caster User Directory: {}".format(_USER_DIR))
+    report_user_dir()

--- a/castervoice/rules/ccr/recording_rules/bringme.py
+++ b/castervoice/rules/ccr/recording_rules/bringme.py
@@ -18,6 +18,27 @@ from castervoice.lib.merge.selfmod.selfmodrule import BaseSelfModifyingRule
 from castervoice.lib.merge.state.short import R
 
 
+def _base_path_dir():
+    configured_base_path = settings.settings(["paths", "BASE_PATH"], "")
+    if configured_base_path:
+        return Path(configured_base_path)
+    return Path(__file__).resolve().parents[3]
+
+
+def _user_dir_path():
+    configured_user_dir = settings.settings(["paths", "USER_DIR"], "")
+    if configured_user_dir:
+        return Path(configured_user_dir)
+    return Path(settings.detected_user_dir())
+
+
+def _bringme_config_path():
+    configured_bringme_path = settings.settings(["paths", "SM_BRINGME_PATH"], "")
+    if configured_bringme_path:
+        return configured_bringme_path
+    return str(_user_dir_path().joinpath("settings", "sm_bringme.toml"))
+
+
 class BringRule(BaseSelfModifyingRule):
     """
     BringRule adds entries to a 2-layered map which can be described as
@@ -34,14 +55,14 @@ class BringRule(BaseSelfModifyingRule):
     _explorer_context = AppContext("explorer.exe") | contexts.DIALOGUE_CONTEXT
     _terminal_context = contexts.TERMINAL_CONTEXT
     # Paths
-    _terminal_path = settings.settings(["paths", "TERMINAL_PATH"])
+    _terminal_path = settings.settings(["paths", "TERMINAL_PATH"], "")
     _explorer_path = str(Path("C:\\Windows\\explorer.exe"))
-    _source_dir = Path(settings.settings(["paths", "BASE_PATH"])).parents[0]
-    _user_dir = settings.settings(["paths", "USER_DIR"])
+    _source_dir = _base_path_dir().parent
+    _user_dir = _user_dir_path()
     _home_dir = Path.home()
 
     def __init__(self, **kwargs):
-        super(BringRule, self).__init__(settings.settings(["paths", "SM_BRINGME_PATH"]), **kwargs)
+        super(BringRule, self).__init__(_bringme_config_path(), **kwargs)
 
     def _initialize(self):
         """

--- a/tests/lib/test_settings.py
+++ b/tests/lib/test_settings.py
@@ -28,6 +28,7 @@ class TestSettings(TestCase):
 
         self.assertNotIn("WSR_RUNTIME_PYTHON_PATH", defaults["paths"])
         self.assertNotIn("KALDI_RUNTIME_PYTHON_PATH", defaults["paths"])
+        self.assertNotIn("PYTHONW", defaults["paths"])
 
     def test_runtime_hidden_console_binary_prefers_active_runtime(self):
         runtime_pythonw = "C:/Caster/.venv/Scripts/pythonw.exe"
@@ -35,6 +36,14 @@ class TestSettings(TestCase):
         settings.SETTINGS = {"paths": {"PYTHONW": "C:/Legacy/pythonw.exe"}}
 
         with patch("castervoice.lib.settings.os.path.isfile", side_effect=lambda path: path == runtime_pythonw):
+            self.assertEqual(runtime_pythonw, settings.runtime_hidden_console_binary())
+
+    def test_runtime_hidden_console_binary_ignores_configured_fallback(self):
+        runtime_pythonw = "C:/Caster/.venv/Scripts/pythonw.exe"
+        settings.SETTINGS = {"paths": {"PYTHONW": "C:/Legacy/pythonw.exe"}}
+
+        with patch("castervoice.lib.settings._hidden_console_binary_for", return_value=runtime_pythonw), \
+                patch("castervoice.lib.settings.os.path.isfile", return_value=False):
             self.assertEqual(runtime_pythonw, settings.runtime_hidden_console_binary())
 
     def test_detected_user_dir_prefers_environment_override(self):

--- a/tests/lib/test_settings.py
+++ b/tests/lib/test_settings.py
@@ -15,7 +15,6 @@ class TestSettings(TestCase):
         settings.SYSTEM_INFORMATION = None
         settings._BASE_PATH = None
         settings._USER_DIR = None
-        settings._USER_DIR_REPORTED = False
         settings._SETTINGS_PATH = None
 
     def test_runtime_python_paths_removed_from_defaults(self):
@@ -52,12 +51,3 @@ class TestSettings(TestCase):
             self.assertEqual("C:/Users/Main/CasterData", settings.detected_user_dir())
 
         user_data_dir.assert_not_called()
-
-    def test_report_user_dir_uses_default_location_once(self):
-        with patch("castervoice.lib.settings.os.getenv", return_value=None), \
-                patch("castervoice.lib.settings.user_data_dir", return_value="C:/Users/Main/AppData/Local/caster"), \
-                patch("castervoice.lib.settings.printer.out") as printer_out:
-            self.assertEqual("C:/Users/Main/AppData/Local/caster", settings.report_user_dir())
-            self.assertEqual("C:/Users/Main/AppData/Local/caster", settings.report_user_dir())
-
-        printer_out.assert_called_once_with("Caster User Directory: C:/Users/Main/AppData/Local/caster")

--- a/tests/lib/test_settings.py
+++ b/tests/lib/test_settings.py
@@ -1,0 +1,54 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from castervoice.lib import settings
+
+
+class TestSettings(TestCase):
+
+    def setUp(self):
+        self.addCleanup(self._reset_settings_state)
+        self._reset_settings_state()
+
+    def _reset_settings_state(self):
+        settings.SETTINGS = None
+        settings.SYSTEM_INFORMATION = None
+        settings._BASE_PATH = None
+        settings._USER_DIR = None
+        settings._USER_DIR_REPORTED = False
+        settings._SETTINGS_PATH = None
+
+    def test_runtime_python_paths_removed_from_defaults(self):
+        with patch.object(settings, "_BASE_PATH", "C:/Caster/castervoice"), \
+                patch.object(settings, "_USER_DIR", "C:/Users/Main/AppData/Local/caster"), \
+                patch.object(settings, "SYSTEM_INFORMATION", {"hidden console binary": "C:/Python/pythonw.exe"}), \
+                patch.object(settings, "_validate_engine_path", return_value=""), \
+                patch("castervoice.lib.settings.os.path.isfile", return_value=False):
+            defaults = settings._get_defaults()
+
+        self.assertNotIn("WSR_RUNTIME_PYTHON_PATH", defaults["paths"])
+        self.assertNotIn("KALDI_RUNTIME_PYTHON_PATH", defaults["paths"])
+
+    def test_runtime_hidden_console_binary_prefers_active_runtime(self):
+        runtime_pythonw = "C:/Caster/.venv/Scripts/pythonw.exe"
+        settings.SYSTEM_INFORMATION = {"hidden console binary": runtime_pythonw}
+        settings.SETTINGS = {"paths": {"PYTHONW": "C:/Legacy/pythonw.exe"}}
+
+        with patch("castervoice.lib.settings.os.path.isfile", side_effect=lambda path: path == runtime_pythonw):
+            self.assertEqual(runtime_pythonw, settings.runtime_hidden_console_binary())
+
+    def test_detected_user_dir_prefers_environment_override(self):
+        with patch("castervoice.lib.settings.os.getenv", return_value="C:/Users/Main/CasterData"), \
+                patch("castervoice.lib.settings.user_data_dir") as user_data_dir:
+            self.assertEqual("C:/Users/Main/CasterData", settings.detected_user_dir())
+
+        user_data_dir.assert_not_called()
+
+    def test_report_user_dir_uses_default_location_once(self):
+        with patch("castervoice.lib.settings.os.getenv", return_value=None), \
+                patch("castervoice.lib.settings.user_data_dir", return_value="C:/Users/Main/AppData/Local/caster"), \
+                patch("castervoice.lib.settings.printer.out") as printer_out:
+            self.assertEqual("C:/Users/Main/AppData/Local/caster", settings.report_user_dir())
+            self.assertEqual("C:/Users/Main/AppData/Local/caster", settings.report_user_dir())
+
+        printer_out.assert_called_once_with("Caster User Directory: C:/Users/Main/AppData/Local/caster")


### PR DESCRIPTION
## Description

This PR extracts engine-agnostic runtime and user-directory fixes from the Kaldi installer work into a standalone change.

It updates subprocess-based helpers to use the active runtime's hidden-console Python binary instead of a stale `paths.PYTHONW` value from `settings.toml`, centralizes user-directory detection/reporting in `settings.py`, and makes `bringme` derive base, user, and config paths safely when those settings keys are absent.

## Motivation and Context

The Kaldi installer branch exposed a broader runtime bug: when Caster is launched from a repo-local virtual environment, helper processes can still start with an outdated configured `PYTHONW` path. That behavior is not Kaldi-specific, so the fix belongs in shared runtime and path handling rather than in the installer PR.

This change also makes user-directory resolution explicit and consistent, which reduces path failures when optional settings entries such as `BASE_PATH`, `USER_DIR`, or `SM_BRINGME_PATH` are missing.

## How Has This Been Tested

- `python -m py_compile castervoice/lib/settings.py castervoice/asynch/hmc/h_launch.py castervoice/asynch/hud_support.py castervoice/lib/navigation.py castervoice/rules/ccr/recording_rules/bringme.py tests/lib/test_settings.py`
- `python -m unittest tests.lib.test_settings`

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

- [ ] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how multiple helper subprocesses (HUD, HMC, mouse grids) are launched and how the user directory is resolved, which could affect startup on different Windows/venv setups.
> 
> **Overview**
> Fixes helper-process launching to always use the *current runtime’s* hidden-console Python binary via `settings.runtime_hidden_console_binary()` instead of relying on a potentially stale `paths.PYTHONW` value.
> 
> Centralizes user-directory resolution in `settings.detected_user_dir()`, removes `PYTHONW` from default settings generation, and hardens `bringme` path derivation to safely fall back when `BASE_PATH`, `USER_DIR`, `TERMINAL_PATH`, or `SM_BRINGME_PATH` are missing.
> 
> Adds unit tests covering the new runtime binary selection and user-dir detection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dc8993b59215920f7d96f3065e9a93ad8c315e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->