### PR TITLE
[codex] Fix bring-me transformer file path

### DIFF
--- a/castervoice/rules/ccr/recording_rules/bringme.py
+++ b/castervoice/rules/ccr/recording_rules/bringme.py
@@ -245,7 +245,7 @@ class BringRule(BaseSelfModifyingRule):
             "caster log file": str(Path(_user_dir).joinpath("log.txt")),
 
             # Simplified Transformer
-            "caster transformer file": str(Path(_user_dir).joinpath("transformers/words.txt")),
+            "caster transformer file": str(Path(_user_dir).joinpath(ContentRoot.USER_DIR).joinpath("transformers/words.txt")),
         }
     }
 


### PR DESCRIPTION
## Description

This pull request fixes the default BringMe transformer file path so it resolves from the user content root.

## Related Issue

None.

## Motivation and Context

The default path for the BringMe transformer file was being resolved from the wrong location. It should point into the configured user content root so the default file lookup matches the rest of the user-space layout.

## How Has This Been Tested

- `python -m py_compile castervoice/rules/ccr/recording_rules/bringme.py`
- No targeted automated tests were run.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

- [ ] I have read the CONTRIBUTING document.
- [ ] My code follows the code style of this project.
- [ ] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [ ] I have checked for and utilized existing command phrases from within Caster (delete if not applicable).
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.